### PR TITLE
Fix input prompts for slip39.recovery

### DIFF
--- a/slip39/recovery/main.py
+++ b/slip39/recovery/main.py
@@ -81,7 +81,7 @@ decryption and seed generation.  It has no effect for SLIP-39 recovery.
 
     # If BIP-39 recovery designated, only a single mnemonic is allowed:
     secret			= None
-    algo			= "SLIP-39" if args.bip39 is None else "BIP-39"
+    algo			= "BIP-39" if args.bip39 else "SLIP-39"
     mnemonics			= args.mnemonic or []
     if args.bip39:
         # Recover actual BIP-39 Mnemonic.  By default, outputs the generated 512-bit wallet Seed.

--- a/slip39/version.py
+++ b/slip39/version.py
@@ -1,2 +1,2 @@
-__version_info__		= ( 9, 0, 3 )
+__version_info__		= ( 9, 0, 4 )
 __version__			= '.'.join( map( str, __version_info__ ))


### PR DESCRIPTION
o No functional changes; the output prompt confused BIP/SLIP-39