### PR TITLE
Simplify layout of mnemonic cards

### DIFF
--- a/slip39/defaults.py
+++ b/slip39/defaults.py
@@ -48,13 +48,13 @@ FONTS				= dict(
 )
 
 #                                  Y      X       Margin
-BUSINESS_CARD			= (2,     3+1/2), 1/32  # noqa: E241
-CREDIT_CARD			= (2+1/4, 3+3/8), 1/32
-INDEX_CARD			= (3,     5),     1/16  # noqa: E241
+BUSINESS_CARD			= (2,     3+1/2), 1/8   # noqa: E241
+CREDIT_CARD			= (2+1/4, 3+3/8), 1/8
+INDEX_CARD			= (3,     5),     1/8   # noqa: E241
 HALF_LETTER			= (13.5/3,8),     1/8   # noqa: E241 (actually, 2/letter, 3/legal)
 THIRD_LETTER			= (13.5/4,8),     1/8   # noqa: E241 (actually, 3/letter, 4/legal)
 QUARTER_LETTER			= (10.5/4,8),     1/8   # noqa: E241 (actually, 4/letter, 5/legal)
-PHOTO_CARD			= (3+1/2, 5+1/2), 1/16  # prints on 4x6 photo paper w/ 1/4" default outer border
+PHOTO_CARD			= (3+1/2, 5+1/2), 1/8   # prints on 4x6 photo paper w/ 1/4" default outer border
 
 # SLIP-39 Mnemonic Card Sizes
 CARD				= 'business'
@@ -108,7 +108,7 @@ BITS_BIP39			= BITS + (160, 192, 224)
 
 MNEM_ROWS_COLS			= {
     20:	( 7, 3),		# 128-bit seed
-    33:	(11, 3),		# 256-bit seed
+    33:	( 9, 4),		# 256-bit seed
     59:	(12, 5),		# 512-bit seed, eg. from BIP-39 (Unsupported on Trezor)
 }
 

--- a/slip39/layout/components.py
+++ b/slip39/layout/components.py
@@ -239,13 +239,6 @@ def layout_card(
     β			= math.atan( b / a )
     rotate		= 90 - math.degrees( β )
 
-    for c_n in range( 16 ):  # SLIP-39 supports up to 16 groups
-        card_interior.add_region_proportional( Text(
-            f'card-g{c_n}', x1=c/b * 8/100, y1=-2/32, x2=c/b * 92/100, y2=10/32,
-            foreground	= int( COLOR[c_n % len( COLOR )], 16 ),
-            rotate	= -rotate,
-            bold	= True,
-        ))
     card_interior.add_region_proportional( Text(
         'card-watermark', x1=5/100, y1=14/16, x2=c/b * 95/100, y2=17/16,
         foreground	= int( COLOR[-2], 16 ),
@@ -253,52 +246,18 @@ def layout_card(
         align		= 'L'
     ))
 
-    # Rotation is downward around upper-left corner; so, lower-left corner will shift 1 height
-    # leftward and upward; so start 1 height right and down.
-    link_length		= card_interior.h
-    link_height		= link_length * 6/32
-    card_interior.add_region(
-        Text(
-            'card-link',
-            x1		= card_interior.x1 + link_height,
-            y1		= card_interior.y1,
-            x2		= card_interior.x1 + link_height + link_length,
-            y2		= card_interior.y1 + link_height,
-            rotate	= -90,				# along left border of card
-            foreground	= int( COLOR[-3], 16 ), 	# Light grey
-            align	= 'R'
-        )
-    )
-
     card_top			= card_interior.add_region_proportional(
-        Region( 'card-top', x1=0, y1=0, x2=1, y2=1/4 )
+        Region( 'card-top', x1=0, y1=0, x2=1, y2=1/8 )
     )
     card_bottom			= card_interior.add_region_proportional(
         Region( 'card-bottom', x1=0, y1=1/4, x2=1, y2=1 )
     )
     card_mnemonics		= card_bottom.add_region_proportional(
-        Region( 'card-mnemonics', x1=0, y1=0, x2=13/16, y2=1 )
+        Region( 'card-mnemonics', x1=0, y1=0, x2=1, y2=1 )
     )
 
-    # QR codes sqaare, and anchored to top and bottom of card.
-    card_bottom.add_region_proportional(
-        Image( 'card-qr1', x1=13/16, y1=0, x2=1, y2=1/2 )
-    ).square( justify='TR' )
-    card_bottom.add_region_proportional(
-        Image( 'card-qr2', x1=13/16, y1=1/2, x2=1, y2=1 )
-    ).square( justify='BR' )
-
     card_top.add_region_proportional(
-        Text( 'card-title', x1=0, y1=0, x2=1, y2=40/100, bold=True )
-    )
-    card_top.add_region_proportional(
-        Text( 'card-requires', x1=0, y1=40/100, x2=1, y2=66/100, align='C', italic=True )
-    )
-    card_top.add_region_proportional(
-        Text( 'card-crypto1', x1=0, y1=66/100, x2=1, y2=83/100, align='R' )
-    )
-    card_top.add_region_proportional(
-        Text( 'card-crypto2', x1=0, y1=83/100, x2=1, y2=100/100, align='R' )
+        Text( 'card-title', x1=0, y1=0, x2=1, y2=1, bold=True, align='C')
     )
 
     assert num_mnemonics in MNEM_ROWS_COLS, \

--- a/slip39/layout/pdf.py
+++ b/slip39/layout/pdf.py
@@ -313,7 +313,7 @@ def produce_pdf(
                 page_n		= p
             card_n	       += 1
 
-            tpl['card-title']	= f"{name} : {g_name} : Card {mn_n+1} of {len(g_mnems)}"
+            tpl['card-title']	= f"{name} : {g_name}"
             if watermark:
                 tpl['card-watermark'] = watermark
             for n,m in enumerate_mnemonic( mnem ).items():

--- a/slip39/layout/pdf.py
+++ b/slip39/layout/pdf.py
@@ -313,15 +313,7 @@ def produce_pdf(
                 page_n		= p
             card_n	       += 1
 
-            tpl['card-title']	= f"SLIP39 {g_name}({mn_n+1}/{len(g_mnems)}) for: {name}"
-            tpl['card-requires'] = requires
-            tpl['card-crypto1']	= f"{accounts[0][0].crypto} {accounts[0][0].path}: {accounts[0][0].address}"
-            tpl['card-qr1']	= qr[0].get_image()
-            if len( accounts[0] ) > 1:
-                tpl['card-crypto2'] = f"{accounts[0][1].crypto} {accounts[0][1].path}: {accounts[0][1].address}"
-                tpl['card-qr2']	= qr[1].get_image()
-            tpl[f'card-g{g_n}']	= f"{g_name:7.7}..{mn_n+1}" if len(g_name) > 8 else f"{g_name} {mn_n+1}"
-            tpl['card-link']	= 'slip39.com'
+            tpl['card-title']	= f"{name} : {g_name} : Card {mn_n+1} of {len(g_mnems)}"
             if watermark:
                 tpl['card-watermark'] = watermark
             for n,m in enumerate_mnemonic( mnem ).items():
@@ -442,7 +434,7 @@ def write_pdfs(
             g_nam_max		= max( map( len, details.groups.keys() ))
             for g_name,(g_of,g_mnems) in details.groups.items():
                 for i,mnem in enumerate( g_mnems ):
-                    print( f"{name} {g_name:{g_nam_max}} {i+1}: {mnem}" )
+                    print( f"{name}: {g_name}: {i+1} of {len(g_mnems)}: {mnem}" )
 
         # Unless no card_format (False) or paper wallet password specified, produce a PDF containing
         # the SLIP-39 mnemonic recovery cards; remember the deduced (<pdf_paper>,<pdf_orient>).  If


### PR DESCRIPTION
Increase margin for smaller cards.

Don't print wallet addresses and QR codes on cards. I don't want the people keeping my SLIP-39 cards to know:

- That these cards protect some cryptocurrencies
- Which cryptocurrencies I might be interested in
- The addresses of my wallets

Don't print the group composition on the cards. I don't want the people keeping my SLIP-39 cards to know the composition (names, numbers and thresholds) of the other groups.

Don't print the group name diagonally on each card. Mnemonic words should be as readable as possible. No text or watermark should be obscuring these mnemonic words.

Bug: https://github.com/pjkundert/python-slip39/issues/11
