### PR TITLE
Fix width of quarter-, third- and half-letter formats

### DIFF
--- a/slip39/defaults.py
+++ b/slip39/defaults.py
@@ -51,9 +51,9 @@ FONTS				= dict(
 BUSINESS_CARD			= (2,     3+1/2), 1/32  # noqa: E241
 CREDIT_CARD			= (2+1/4, 3+3/8), 1/32
 INDEX_CARD			= (3,     5),     1/16  # noqa: E241
-HALF_LETTER			= (13.5/3,8),     1/8   # noqa: E241 (actually, 2/letter, 3/legal)
-THIRD_LETTER			= (13.5/4,8),     1/8   # noqa: E241 (actually, 3/letter, 4/legal)
-QUARTER_LETTER			= (10.5/4,8),     1/8   # noqa: E241 (actually, 4/letter, 5/legal)
+HALF_LETTER			= (13.5/3,7+3/4), 1/8   # noqa: E241 (actually, 2/letter, 3/legal)
+THIRD_LETTER			= (13.5/4,7+3/4), 1/8   # noqa: E241 (actually, 3/letter, 4/legal)
+QUARTER_LETTER			= (10.5/4,7+3/4), 1/8   # noqa: E241 (actually, 4/letter, 5/legal)
 PHOTO_CARD			= (3+1/2, 5+1/2), 1/16  # prints on 4x6 photo paper w/ 1/4" default outer border
 
 # SLIP-39 Mnemonic Card Sizes
@@ -64,13 +64,14 @@ CARD_SIZES			= dict(
     index	= INDEX_CARD,
     half	= HALF_LETTER,
     third	= THIRD_LETTER,
-    quarter	= THIRD_LETTER,
+    quarter	= QUARTER_LETTER,
     photo	= PHOTO_CARD,
 )
 
 # Paper Wallet Bill Sizes, by default on PAPER format paper
 WALLET				= 'quarter'
 WALLET_SIZES			= dict(
+    index	= INDEX_CARD,
     half	= HALF_LETTER,
     third	= THIRD_LETTER,
     quarter	= QUARTER_LETTER,


### PR DESCRIPTION
To allow them to be printed on A4 paper.

Bug: https://github.com/pjkundert/python-slip39/issues/10